### PR TITLE
Use deep-freeze-strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon": "^1.17.2"
   },
   "dependencies": {
-    "deep-freeze": "0.0.1"
+    "deep-freeze-strict": "1.1.1"
   }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-import deepFreeze from 'deep-freeze'
+import deepFreeze from 'deep-freeze-strict'
 
 /**
  * Middleware that prevents state from being mutated anywhere in the app.

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -48,4 +48,17 @@ describe('redux-freeze', () => {
       })
     })
   })
+
+  it('should throw when mutation occurs on an object without the Object prototype', () => {
+    const state = Object.create(null, { x: {} })
+    const getState = () => state
+    const next = () => {}
+
+    freeze({dispatch, getState})(next)()
+
+    assert.throws(() => {
+      const state = getState()
+      state.x.y = 0
+    }, TypeError)
+  })
 })


### PR DESCRIPTION
Deep-freeze does not appear to be maintained and
does not support recursively freezing objects that
were created with Object.create(null).
