### PR TITLE
Freeze store initial state

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,6 +4,7 @@ import deepFreeze from 'deep-freeze-strict'
  * Middleware that prevents state from being mutated anywhere in the app.
  */
 export default function freeze(store) {
+  freezeStoreState(store)
   return next => action => {
     freezeStoreState(store)
     try {

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -61,4 +61,12 @@ describe('redux-freeze', () => {
       state.x.y = 0
     }, TypeError)
   })
+
+  it('should freeze initial state', () => {
+    const state = {}
+    const getState = () => state
+
+    freeze({dispatch, getState})
+    assert.isTrue(Object.isFrozen(state))
+  })
 })


### PR DESCRIPTION
redux-freeze currently does not freeze the store initial state, you need to have at least one dispatch before the state get frozen.

While this should not be a problem is most cases, there is a possibility that somebody calls `store.getState` before the first dispatch and mess with the state.

This PR will prevent that by freezing the initial state.